### PR TITLE
Rayable trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ray-debug"
-version = "0.0.3"
+version = "0.0.4"
 edition = "2021"
 repository = "https://github.com/larsmbergvall/ray-debug"
 keywords = ["debug", "ray"]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A Rust adapter for Spatie's fantastic debugging tool, [Ray](https://spatie.be/products/ray).
 
-**This is a work in progress, so breaking changes are likely to occur! Also, not all Ray features are yet implemented!**
+**This is a work in progress, so bugs and breaking changes are likely to occur! Also, not all Ray features are yet implemented!**
 
 ## Setup
 
@@ -21,16 +21,16 @@ RAY_PORT=23517
 Only basic debugging is implemented at the moment, so you can use it like:
 
 ```rust
-use ray_debug::{ray, ray_log};
+use ray_debug::ray;
 
 // ...
 fn do_stuff() {
     // ...
     ray(&some_struct);
-    ray_log("foo");
     
     // To set color:
     ray(&some_struct).unwrap().orange();
-    ray_log("foo").unwrap().green();
 }
 ```
+
+Your struct needs to implement the trait `serde::Serialize` for this to work. You can also call `ray()` with strings, integers etc.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,22 +3,22 @@ use std::error::Error;
 use crate::meta::Meta;
 use crate::payloads::log_payload::LogPayload;
 use crate::payloads::payload::Payload;
-use serde::Serialize;
 
 use crate::ray_request::RayRequest;
+use crate::rayable::Rayable;
 
 mod ray_color;
 mod ray_request;
 
+#[deprecated(since = "0.0.4", note = "This will be removed; use ray() instead")]
 pub fn ray_log<T: Into<String>>(value: T) -> Result<RayRequest, Box<dyn Error>> {
     RayRequest::log(value.into(), None).send()
 }
 
-pub fn ray<T: Serialize>(value: &T) -> Result<RayRequest, Box<dyn Error>> {
-    let json = helpers::get_json(value, false);
-    let serde_value = serde_json::from_str(&json).unwrap();
+pub fn ray<T: Rayable>(value: T) -> Result<RayRequest, Box<dyn Error>> {
+    let request: RayRequest = value.into_ray_request();
 
-    RayRequest::html(helpers::value_to_html(&serde_value), None).send()
+    request.send()
 }
 
 pub fn ray_charles() -> Result<RayRequest, Box<dyn Error>> {
@@ -35,5 +35,6 @@ mod helpers;
 mod meta;
 mod origin;
 mod payloads;
+pub mod rayable;
 #[cfg(test)]
 mod tests;

--- a/src/rayable.rs
+++ b/src/rayable.rs
@@ -1,0 +1,52 @@
+use serde::Serialize;
+use serde_json::{Number, Value};
+
+use crate::helpers;
+use crate::ray_request::RayRequest;
+
+pub trait Rayable {
+    fn into_ray_request(self) -> RayRequest;
+}
+
+impl<T: serde::Serialize> Rayable for &T {
+    fn into_ray_request(self) -> RayRequest {
+        to_html_request(&self)
+    }
+}
+
+impl Rayable for String {
+    fn into_ray_request(self) -> RayRequest {
+        to_html_request(&self)
+    }
+}
+
+impl Rayable for &str {
+    fn into_ray_request(self) -> RayRequest {
+        RayRequest::log(self, None)
+    }
+}
+
+impl Rayable for Value {
+    fn into_ray_request(self) -> RayRequest {
+        to_html_request(&self)
+    }
+}
+
+impl Rayable for Number {
+    fn into_ray_request(self) -> RayRequest {
+        to_html_request(&self)
+    }
+}
+
+impl Rayable for i64 {
+    fn into_ray_request(self) -> RayRequest {
+        to_html_request(&self)
+    }
+}
+
+fn to_html_request<T: Serialize>(value: &T) -> RayRequest {
+    let json = helpers::get_json(value, false);
+    let serde_value = serde_json::from_str(&json).unwrap();
+
+    RayRequest::html(helpers::value_to_html(&serde_value), None)
+}

--- a/src/rayable.rs
+++ b/src/rayable.rs
@@ -44,6 +44,12 @@ impl Rayable for i64 {
     }
 }
 
+impl<T: serde::Serialize> Rayable for Vec<T> {
+    fn into_ray_request(self) -> RayRequest {
+        to_html_request(&self)
+    }
+}
+
 fn to_html_request<T: Serialize>(value: &T) -> RayRequest {
     let json = helpers::get_json(value, false);
     let serde_value = serde_json::from_str(&json).unwrap();

--- a/src/tests/integration/synchronous_test.rs
+++ b/src/tests/integration/synchronous_test.rs
@@ -40,3 +40,43 @@ fn sync_ray_works() {
         panic!("{}", e);
     }
 }
+
+#[ignore]
+#[test]
+fn generic_ray_works_with_serializable_struct() {
+    let user = TestUser {
+        name: "::name::".into(),
+        age: 42,
+        country: "SE".into(),
+        email: "sync_ray_works@localhost.example".into(),
+    };
+
+    if let Err(e) = ray(&user).unwrap().green() {
+        panic!("{}", e);
+    }
+
+    if let Err(e) = ray("&str").unwrap().green() {
+        panic!("{}", e);
+    }
+
+    let a_string_ref = String::from("&a_string");
+    let a_string = String::from("a_string");
+
+    if let Err(e) = ray(&a_string_ref).unwrap().green() {
+        panic!("{}", e);
+    }
+
+    if let Err(e) = ray(a_string).unwrap().green() {
+        panic!("{}", e);
+    }
+
+    if let Err(e) = ray(123).unwrap().green() {
+        panic!("{}", e);
+    }
+
+    let tiny_int: u8 = 5;
+
+    if let Err(e) = ray(&tiny_int).unwrap().green() {
+        panic!("{}", e);
+    }
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -5,6 +5,7 @@ mod integration;
 mod meta_test;
 mod origin_test;
 mod ray_request_test;
+mod rayable_test;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct TestUser {
@@ -12,6 +13,17 @@ pub struct TestUser {
     pub age: u8,
     pub country: String,
     pub email: String,
+}
+
+impl Default for TestUser {
+    fn default() -> Self {
+        Self {
+            name: "John Doe".to_string(),
+            age: 42,
+            country: "SE".to_string(),
+            email: "some_email@localhost.example".to_string(),
+        }
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/tests/rayable_test.rs
+++ b/src/tests/rayable_test.rs
@@ -1,0 +1,76 @@
+use crate::payloads::payload::Payload;
+use crate::ray_request::RayRequest;
+use crate::rayable::Rayable;
+use crate::tests::TestUser;
+use std::any::{Any, TypeId};
+
+#[test]
+fn it_can_convert_string_to_ray_request() {
+    let string_value = String::from("foo");
+
+    let request = assert_it_can_convert_value(string_value);
+
+    match request.payloads.first().unwrap() {
+        Payload::Html(_) => {}
+        _ => panic!("Payload is not HTML type!"),
+    };
+}
+
+#[test]
+fn it_can_convert_string_slice_to_ray_request() {
+    let request = assert_it_can_convert_value("foo");
+
+    match request.payloads.first().unwrap() {
+        Payload::Log(_) => {}
+        _ => panic!("Payload is not Log type!"),
+    };
+}
+
+#[test]
+fn it_can_convert_number_to_ray_request() {
+    let request = assert_it_can_convert_value(123);
+
+    match request.payloads.first().unwrap() {
+        Payload::Html(_) => {}
+        _ => panic!("Payload is not HTML type!"),
+    };
+}
+
+#[test]
+fn it_can_convert_serializable_struct_to_ray_request() {
+    let user = TestUser::default();
+
+    let request = assert_it_can_convert_value(&user);
+
+    match request.payloads.first().unwrap() {
+        Payload::Html(_) => {}
+        _ => panic!("Payload is not HTML type!"),
+    };
+}
+
+#[test]
+fn it_can_convert_vec_of_serializable_structs_to_ray_request() {
+    let user = TestUser::default();
+    let user2 = TestUser::default();
+
+    let vec = vec![user, user2];
+
+    let request = assert_it_can_convert_value(&vec);
+
+    match request.payloads.first().unwrap() {
+        Payload::Html(_) => {}
+        _ => panic!("Payload is not HTML type!"),
+    };
+}
+
+fn assert_it_can_convert_value<T: Rayable>(value: T) -> RayRequest {
+    let request = rayable(value);
+
+    assert_eq!(request.type_id(), TypeId::of::<RayRequest>());
+
+    request
+}
+
+fn rayable<T: Rayable>(value: T) -> RayRequest {
+    value.into_ray_request()
+}


### PR DESCRIPTION
Made a Rayable trait so that the `ray()` function can take pretty much anything serializable instead of having separate methods such as `ray_log()` for string slices